### PR TITLE
Bump to Symfony 6.4||7, PHP 8

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -3,6 +3,7 @@ on:
     push:
         branches:
             - "master"
+            - "tac"
     pull_request: ~
     workflow_dispatch: ~
 
@@ -15,7 +16,7 @@ jobs:
         strategy:
             matrix:
                 php-version:
-                    - "7.4"
+                    - "8.1"
 
                 dependencies:
                     - "highest"
@@ -53,8 +54,6 @@ jobs:
         strategy:
             matrix:
                 php-version:
-                    - "7.4"
-                    - "8.0"
                     - "8.1"
 
                 dependencies:
@@ -62,13 +61,8 @@ jobs:
                     - "highest"
 
                 symfony:
-                    - "^4.4"
-                    - "^5.4"
-                    - "^6.0"
-
-                exclude:
-                    -   php-version: "7.4"
-                        symfony: "^6.0"
+                    - "^6.4"
+                    - "^7.1"
 
         steps:
             -   name: "Checkout"
@@ -113,11 +107,11 @@ jobs:
                 symfony:
                     - "^4.4"
                     - "^5.4"
-                    - "^6.0"
+                    - "^6.4 || ^7.1"
 
                 exclude:
                     -   php-version: "7.4"
-                        symfony: "^6.0"
+                        symfony: "^6.4 || ^7.1"
 
         steps:
             -   name: "Checkout"
@@ -160,11 +154,11 @@ jobs:
                 symfony:
                     - "^4.4"
                     - "^5.4"
-                    - "^6.0"
+                    - "^6.4 || ^7.1"
 
                 exclude:
                     -   php-version: "7.4"
-                        symfony: "^6.0"
+                        symfony: "^6.4 || ^7.1"
 
         steps:
             -   name: "Checkout"

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -97,21 +97,18 @@ jobs:
         strategy:
             matrix:
                 php-version:
-                    - "7.4"
-                    - "8.0"
                     - "8.1"
+                    - "8.2"
+                    - "8.3"
+                    - "8.4"
 
                 dependencies:
                     - "highest"
 
                 symfony:
-                    - "^4.4"
-                    - "^5.4"
-                    - "^6.4 || ^7.1"
-
-                exclude:
-                    -   php-version: "7.4"
-                        symfony: "^6.4 || ^7.1"
+                    - "^6.4"
+                    - "^7.1"
+                    - "^7.2"
 
         steps:
             -   name: "Checkout"

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -106,9 +106,9 @@ jobs:
                     - "highest"
 
                 symfony:
-                    - "^6.4"
-                    - "^7.1"
-                    - "^7.2"
+                    - "~6.4.0"
+                    - "~7.1.0"
+                    - "~7.2.0"
 
         steps:
             -   name: "Checkout"

--- a/composer.json
+++ b/composer.json
@@ -10,28 +10,28 @@
         }
     ],
     "require": {
-        "php": ">=7.4",
-        "setono/symfony-main-request-trait": "^1.0",
-        "symfony/config": "^4.4 || ^5.4 || ^6.0",
-        "symfony/dependency-injection": "^4.4 || ^5.4 || ^6.0",
-        "symfony/http-foundation": "^4.4 || ^5.4 || ^6.0",
-        "symfony/http-kernel": "^4.4 || ^5.4 || ^6.0",
-        "twig/twig": "^2.14 || ^3.4"
+        "php": "^8.2",
+        "symfony/config": "^6.4 || ^7.1",
+        "symfony/dependency-injection": "^6.4 || ^7.1",
+        "symfony/http-foundation": "^6.4 || ^7.1",
+        "symfony/http-kernel": "^6.4 || ^7.1",
+        "twig/twig": "^3.4"
     },
     "require-dev": {
         "infection/infection": "^0.26",
         "matomo/device-detector": "^5.0 || ^6.0",
         "matthiasnoback/symfony-dependency-injection-test": "^4.3",
-        "nette/php-generator": "^3.6",
+        "nette/php-generator": "^4.1",
         "phpbench/phpbench": "^1.2",
         "phpspec/prophecy-phpunit": "^2.0",
+        "phpstan/phpstan": "^1.12",
         "phpunit/phpunit": "^9.5",
         "psalm/plugin-phpunit": "^0.18",
         "psalm/plugin-symfony": "^4.0",
         "roave/security-advisories": "dev-latest",
         "setono/code-quality-pack": "^2.2",
-        "symfony/console": "^4.4 || ^5.4 || ^6.0",
-        "symfony/yaml": "^4.4 || ^5.4 || ^6.0",
+        "symfony/console": "^6.4 || ^7.1",
+        "symfony/yaml": "^6.4 || ^7.1",
         "webmozart/assert": "^1.11"
     },
     "prefer-stable": true,

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,0 +1,38 @@
+parameters:
+    level: 9
+    inferPrivatePropertyTypeFromConstructor: true
+    paths:
+        - ./src/
+
+    excludePaths:
+#      - 'src/Resources/skeleton'
+#      - */cache/*
+       analyse:
+          - ./vendor
+
+    reportUnmatchedIgnoredErrors: false
+#    checkMissingIterableValueType: false
+#    checkGenericClassInNonGenericObjectType: false
+    ignoreErrors:
+        - '#Call to an undefined method Symfony\\Component\\Config\\Definition\\Builder\\NodeDefinition::children\(\)\.#'
+        - '#Call to an undefined method Symfony\\Component\\Config\\Definition\\Builder\\NodeParentInterface::scalarNode\(\).#'
+        # Only available in ArrayNodeDefinition which is given
+        # False positive: clients are not dependencies of this project.
+#        -
+#            message: '#Call to an undefined method Symfony\Component\Config\Definition\Builder\NodeDefinition::children#'
+#            path: ./src/Client/Provider
+#        -
+#            message: '#Return typehint of method KnpU\\OAuth2ClientBundle\\Client\\Provider\\[a-zA-Z0-9\\_]+::fetchUser\(\) has invalid type [a-zA-Z0-9\\_]#'
+#            path: ./src/Client/Provider
+        # False positive: using `::class` is not an error for those providers `::getProviderClass()` method.
+#        -
+#            message: '#Class [a-zA-Z0-9\\_]+ not found#'
+#            path: ./src/DependencyInjection/Providers
+
+        # The DependencyInjection returns are very complex to deal with
+#        -
+#            message: '#.*NodeParentInterface\|null.*#'
+#            path: ./src/DependencyInjection/Providers
+#        -
+#            message: '#.*NodeDefinition::children.*#'
+#            path: ./src/DependencyInjection

--- a/src/BotDetector/BotDetector.php
+++ b/src/BotDetector/BotDetector.php
@@ -53,7 +53,7 @@ final class BotDetector implements BotDetectorInterface
     public function isBotRequest(Request $request = null): bool
     {
         $request = $request ?? $this->requestStack->getCurrentRequest();
-        if (empty($request)) {
+        if (null === $request) {
             return false;
         }
         assert($request instanceof Request);

--- a/src/BotDetector/BotDetector.php
+++ b/src/BotDetector/BotDetector.php
@@ -19,7 +19,7 @@ final class BotDetector implements BotDetectorInterface
     /**
      * @param list<string>|null $popular
      */
-    public function __construct(private RequestStack $requestStack, array $popular = null)
+    public function __construct(private readonly RequestStack $requestStack, array $popular = null)
     {
         $this->requestStack = $requestStack;
         if (null === $popular) {

--- a/src/BotDetector/BotDetector.php
+++ b/src/BotDetector/BotDetector.php
@@ -10,12 +10,8 @@ use Symfony\Component\HttpFoundation\RequestStack;
 
 final class BotDetector implements BotDetectorInterface
 {
-    use MainRequestTrait;
-
     /** @var array<string, bool> */
     private array $cache = [];
-
-    private RequestStack $requestStack;
 
     /** @var list<string> */
     private array $popular;
@@ -23,7 +19,7 @@ final class BotDetector implements BotDetectorInterface
     /**
      * @param list<string>|null $popular
      */
-    public function __construct(RequestStack $requestStack, array $popular = null)
+    public function __construct(private RequestStack $requestStack, array $popular = null)
     {
         $this->requestStack = $requestStack;
         if (null === $popular) {
@@ -56,13 +52,11 @@ final class BotDetector implements BotDetectorInterface
 
     public function isBotRequest(Request $request = null): bool
     {
-        if (null === $request) {
-            $request = $this->getMainRequestFromRequestStack($this->requestStack);
-            if (null === $request) {
-                return false;
-            }
+        $request = $request ?? $this->requestStack->getCurrentRequest();
+        if (empty($request)) {
+            return false;
         }
-
+        assert($request instanceof Request);
         $userAgent = $request->headers->get('user-agent');
         if (null === $userAgent) {
             return false;

--- a/tests/BotDetector/BotDetectorTest.php
+++ b/tests/BotDetector/BotDetectorTest.php
@@ -41,6 +41,7 @@ final class BotDetectorTest extends TestCase
     {
         $requestStack = new RequestStack();
         $requestStack->push(new Request());
+        assert($requestStack->getCurrentRequest());
         $botDetector = new BotDetector($requestStack);
 
         self::assertFalse($botDetector->isBotRequest());


### PR DESCRIPTION
This still needs some work, in the test matrix and possible in handling the $request object (the trait was removed).

This should probably be a major version release, since the minimum requirements have changed.